### PR TITLE
chore: add pyproject.toml for Frappe tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[project]
+name = "education"
+authors = [
+    { name = "Hybrowlabs Technologies", email = "contact@hybrowlabs.com"}
+]
+description = "Education"
+requires-python = ">=3.10"
+readme = "README.md"
+dynamic = ["version"]
+dependencies = [
+    # "frappe~=15.0.0" # Installed and managed by bench.
+]
+
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+# These dependencies are only installed when developer mode is enabled
+[tool.bench.dev-dependencies]
+# package_name = "~=1.1.0"
+
+[tool.ruff]
+line-length = 110
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "F",
+    "E",
+    "W",
+    "I",
+    "UP",
+    "B",
+]
+ignore = [
+    "B017", # assertRaises(Exception) - should be more specific
+    "B018", # useless expression, not assigned to anything
+    "B023", # function doesn't bind loop variable - will have last iteration's value
+    "B904", # raise inside except without from
+    "E101", # indentation contains mixed spaces and tabs
+    "E402", # module level import not at top of file
+    "E501", # line too long
+    "E741", # ambiguous variable name
+    "F401", # unused imports
+    "F403", # can't detect undefined names from * import
+    "F405", # can't detect undefined names from * import
+    "F722", # syntax error in forward type annotation
+    "W191", # indentation contains tabs
+]
+typing-modules = ["frappe.types.DF"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "tab"
+docstring-code-format = true


### PR DESCRIPTION
## Summary
- add a root `pyproject.toml` for the Education Frappe app
- align project metadata with other Walnut Frappe repos
- add Ruff and bench dev-dependency scaffolding for consistent tooling

## Notes
- no application logic changes
- mirrors the structure used in sibling Frappe repositories
